### PR TITLE
[Feature] #142 전용 무기 ScytheSwing 추가

### DIFF
--- a/HoloCure/Assets/Scripts/Util/CursorCache.cs
+++ b/HoloCure/Assets/Scripts/Util/CursorCache.cs
@@ -6,29 +6,35 @@ namespace Util
 {
     public class CursorCache : MonoBehaviour
     {
-        public static Vector2 MouseScreenPos => _mouseScreenPos;
-        private static Vector2 _mouseScreenPos;
-        public static Vector2 MouseWorldPos => _mouseWorldPos;
-        private static Vector2 _mouseWorldPos;
+        public static Vector2 CursorScreenPosition => _cursorScreenPosition;
+        private static Vector2 _cursorScreenPosition;
+        public static Vector2 CursorWorldPosition => _cursorWorldPosition;
+        private static Vector2 _cursorWorldPosition;
 
         private static Camera _mainCamera;
         private void Awake() => _mainCamera = Camera.main;
+
         private void Start()
         {
             this.UpdateAsObservable()
-                .Subscribe(GetMousePosition);
+                .Subscribe(SetCursorPosition);
         }
-        private static void GetMousePosition(Unit unit)
+
+        private static void SetCursorPosition(Unit unit)
         {
-            _mouseScreenPos = Input.mousePosition;
-            _mouseWorldPos = _mainCamera.ScreenToWorldPoint(_mouseScreenPos);
+            _cursorScreenPosition = Input.mousePosition;
+            _cursorWorldPosition = _mainCamera.ScreenToWorldPoint(_cursorScreenPosition);
         }
-        public static float GetAngleToMouse(Vector2 position)
+
+        public static float GetAngleToCursor(Vector2 position)
         {
-            Vector2 direction = _mouseWorldPos - position;
+            Vector2 direction = _cursorWorldPosition - position;
 
             return Mathf.Atan2(direction.y, direction.x) * Mathf.Rad2Deg;
         }
+
+        public static Vector2 GetDirectionToCursor(Vector2 position) => (_cursorWorldPosition - position).normalized;
+
         public static void SetCameraRotationDefault() => _mainCamera.transform.rotation = default;
     }
 }

--- a/HoloCure/Assets/Scripts/Util/Extensions.cs
+++ b/HoloCure/Assets/Scripts/Util/Extensions.cs
@@ -2,12 +2,15 @@ using System;
 using UniRx;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using Util;
 using Random = UnityEngine.Random;
 
 public static class Extensions
 {
-    public static void RotateLookCursor(this Transform transform, Vector2 startPosition)
-        => transform.rotation = Quaternion.AngleAxis(Util.CursorCache.GetAngleToMouse(startPosition), Vector3.forward);
+    public static void RotateLookCursor(this Transform transform) 
+        => transform.rotation = Quaternion.AngleAxis(CursorCache.GetAngleToCursor(transform.position), Vector3.forward);
+    public static Vector2 GetPositionToCursor(this Vector2 position, float distance) 
+        => CursorCache.GetDirectionToCursor(position) * distance;
     public static void BindViewEvent(this UIBehaviour view, Action<PointerEventData> action, ViewEvent type, Component component)
         => UIBase.BindViewEvent(view, action, type, component);
     public static void BindModelEvent<T>(this ReactiveProperty<T> model, Action<T> action, Component component)

--- a/HoloCure/Assets/Scripts/Weapon/ScytheSwing.cs
+++ b/HoloCure/Assets/Scripts/Weapon/ScytheSwing.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+
+public class ScytheSwing : Weapon
+{
+    private Vector2 _cursorDirectedOffset;
+    protected override void ShootProjectile(int projectileIndex)
+    {
+        Projectile projectile = Managers.Spawn.Projectile.Get();
+
+        _cursorDirectedOffset = weapon2DPosition.GetPositionToCursor(transform.localPosition.x);
+        Vector2 projectileInitPosition = weapon2DPosition + _cursorDirectedOffset;
+
+        projectile.Init(projectileInitPosition, weaponData, weaponCollider,
+            ProjectileOperate);
+        projectile.transform.RotateLookCursor();
+
+        Managers.Sound.Play(SoundID.ScytheSwing);
+    }
+
+    private void ProjectileOperate(Projectile projectile)
+    {
+        projectile.transform.position = weapon2DPosition + _cursorDirectedOffset;
+    }
+}

--- a/HoloCure/Assets/Scripts/Weapon/ScytheSwing.cs.meta
+++ b/HoloCure/Assets/Scripts/Weapon/ScytheSwing.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c6afd6ddc02bf8c418784a17d7b49e26
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/HoloCure/Assets/Scripts/Weapon/Weapon.cs
+++ b/HoloCure/Assets/Scripts/Weapon/Weapon.cs
@@ -8,6 +8,7 @@ public abstract class Weapon : MonoBehaviour
     public ReactiveProperty<int> Level { get; private set; } = new();
     public ItemID Id { get; private set; }
 
+    protected Vector2 weapon2DPosition => transform.position + Vector3.left * transform.localPosition.x;
     protected WeaponLevelData weaponData;
     protected Collider2D weaponCollider;
 
@@ -106,6 +107,4 @@ public abstract class Weapon : MonoBehaviour
     }
 
     protected abstract void ShootProjectile(int projectileIndex);
-
-    protected Vector2 GetWeapon2DPosition() => transform.position;
 }


### PR DESCRIPTION
# 변경된 기능

- 신규캐릭터 칼리의 전용무기 ScytheSwing를 추가하였습니다.

# 제안 사항

- ScytheSwing 스크립트 추가
> 무기를 동작하게 하기위한 스크립트를 추가하였습니다.
> 무기의 그래픽을 좀더 자연스럽게 만들기 위해 커서가 위치한 방향으로 약간 위치를 이동시키도록 만들었습니다.

# 동영상

https://github.com/KIA-PROGRAMMING-38/HoloCure/assets/120005225/8d25a834-92e0-4034-9097-b0db973801d1

# 관련 이슈

- #142 
- #140 