### PR TITLE
[Feature] #207 전용 무기 Orayo 추가

### DIFF
--- a/HoloCure/Assets/Resources/3_Prefab/Orayo.prefab
+++ b/HoloCure/Assets/Resources/3_Prefab/Orayo.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 8110080734835164694}
   - component: {fileID: 8110080734835164695}
   - component: {fileID: 8110080734835164688}
-  - component: {fileID: 8110080734835164689}
+  - component: {fileID: -6291022566057215641}
   m_Layer: 0
   m_Name: Orayo
   m_TagString: Untagged
@@ -134,7 +134,7 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
---- !u!114 &8110080734835164689
+--- !u!114 &-6291022566057215641
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -143,6 +143,6 @@ MonoBehaviour:
   m_GameObject: {fileID: 8110080734835164690}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 727515c2a0437a945bb20b2cf757d58b, type: 3}
+  m_Script: {fileID: 11500000, guid: 73468be501e7dd84bbd4e6cc9ccd2923, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/HoloCure/Assets/Resources/4_DataTable/Item.csv
+++ b/HoloCure/Assets/Resources/4_DataTable/Item.csv
@@ -15,7 +15,7 @@ Id,Name,IconSprite,Type
 2209,Bright Star,spr_SoraWeapon_0,Multishot
 2210,Fox Tail,spr_FubukiWeapon_0,Melee
 2211,Tarot Cards,spr_MioWeapon_0,Multishot
-2212,Orayo,spr_KoronePortrait_0,Multishot
+2212,Orayo,spr_KoroneWeapon_0,Multishot
 2401,Max HP Up,hud_HPicon_0,Stat
 2402,ATK Up,hud_atkicon_0,Stat
 2403,SPD Up,hud_spdicon_0,Stat

--- a/HoloCure/Assets/Resources/4_DataTable/SelectIdol.csv
+++ b/HoloCure/Assets/Resources/4_DataTable/SelectIdol.csv
@@ -13,7 +13,7 @@ IdolID,StartingWeaponID,TitleSprite,IconSprite,DisplaySprite,VtuberName,MaxHp,At
 1110,2210,spr_Title_Fubuki_0,spr_FubukiWeapon_0,spr_Fubuki_idle_0,Shirakami Fubuki,55,1,1.5,5,Fox Tail,Swipes Tail in front at close range
 1111,2211,spr_Title_Mio_0,spr_MioWeapon_0,spr_Mio_idle_0,Ookami Mio,70,0.9,1.4,1,Tarot Cards,Throw a card that quickly returns back.
 1000,2000,spr_Default,spr_Default,spr_Default,,0,0,0,0,,
-1112,2212,spr_Title_Korone_0,spr_KoronePortrait_0,spr_Korone_idle_0,Inugami Korone,60,1,1.4,1,Orayo,Punch towards the front.
+1112,2212,spr_Title_Korone_0,spr_KoroneWeapon_0,spr_Korone_idle_0,Inugami Korone,60,1,1.4,1,Orayo,Punch towards the front.
 1109,2209,spr_Title_Sora_0,spr_SoraWeapon_0,spr_Sora_idle_0,Tokino Sora,65,1,1.4,3,Bright Star,Shoot forward a spinning star.
 1000,2000,spr_Default,spr_Default,spr_Default,,0,0,0,0,,
 1000,2000,spr_Default,spr_Default,spr_Default,,0,0,0,0,,

--- a/HoloCure/Assets/Resources/4_DataTable/WeaponLevelTable.csv
+++ b/HoloCure/Assets/Resources/4_DataTable/WeaponLevelTable.csv
@@ -111,10 +111,10 @@ Id,Level,Description,BaseAttackSequenceTime,MinAttackSequenceTime,StrikeCount,Da
 2211,5,Throw cards farther and increased damage by <color=green>40%</color>.,1.13,0.3,3,2,0.03,0.25,1,1,0,500,0,0,0,0
 2211,6,Throw <color=green>4</color> tarot cards.,1.13,0.3,4,2,0.03,0.25,1,1,0,500,0,0,0,0
 2211,7,Throw <color=green>5</color> tarot cards.,1.13,0.3,5,2,0.03,0.25,1,1,0,500,0,0,0,0
-2212,1,Punch towards the front.,1,0.3,2,0.85,0.07,0.5,1,0.5,0,200,0,0,0,0
-2212,2,Increase attack area by <color=green>25%</color>.,1,0.3,2,0.85,0.07,0.5,1.25,0.5,0,200,0,0,0,0
-2212,3,Increase damage by <color=green>30%</color>.,1,0.3,2,1.1,0.07,0.5,1.25,0.5,0,200,0,0,0,0
-2212,4,Increase amount of punches by <color=green>1</color>.,1,0.3,3,1.1,0.07,0.5,1.25,0.5,0,200,0,0,0,0
-2212,5,Increase attack area by <color=green>25%</color>. Widen Korone's punch range slightly.,1,0.3,3,1.1,0.07,0.5,1.5625,0.5,0,300,0,0,0,0
-2212,6,Increase amount of punches by <color=green>2</color>.,1,0.3,5,1.1,0.07,0.5,1.5625,0.5,0,300,0,0,0,0
-2212,7,Reduce delay between combination punches by <color=green>30%</color>.,0.7,0.3,5,1.1,0.04,0.5,1.5625,0.5,0,300,0,0,0,0
+2212,1,Punch towards the front.,1,0.3,2,0.85,0.05,0.2,1,0.2,0,400,0,0,0,0
+2212,2,Increase attack area by <color=green>25%</color>.,1,0.3,2,0.85,0.05,0.2,1.25,0.2,0,400,0,0,0,0
+2212,3,Increase damage by <color=green>30%</color>.,1,0.3,2,1.1,0.05,0.2,1.25,0.2,0,400,0,0,0,0
+2212,4,Increase amount of punches by <color=green>1</color>.,1,0.3,3,1.1,0.05,0.2,1.25,0.2,0,400,0,0,0,0
+2212,5,Increase attack area by <color=green>25%</color>. Widen Korone's punch range slightly.,1,0.3,3,1.1,0.05,0.2,1.5625,0.2,0,600,0,0,0,0
+2212,6,Increase amount of punches by <color=green>2</color>.,1,0.3,5,1.1,0.05,0.2,1.5625,0.2,0,600,0,0,0,0
+2212,7,Reduce delay between combination punches by <color=green>30%</color>.,0.7,0.2,5,1.1,0.03,0.2,1.5625,0.2,0,600,0,0,0,0

--- a/HoloCure/Assets/Scripts/Weapon/Orayo.cs
+++ b/HoloCure/Assets/Scripts/Weapon/Orayo.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+public class Orayo : CursorTargetingRangedWeapon
+{
+    private const float ANGLE_BETWEEN_STRIKES = 15f;
+    private void Awake() => angleBetweenStrikes = ANGLE_BETWEEN_STRIKES;
+    protected override void SetupStrikeOnPerform(WeaponStrike strike, int strikeIndex)
+    {
+        strike.transform.rotation = centerStrikeRotation * Quaternion.AngleAxis(angles[strikeIndex], Vector3.back);
+
+        Managers.Sound.Play(SoundID.Orayo);
+    }
+}

--- a/HoloCure/Assets/Scripts/Weapon/Orayo.cs.meta
+++ b/HoloCure/Assets/Scripts/Weapon/Orayo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 73468be501e7dd84bbd4e6cc9ccd2923
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# 변경된 기능
신규캐릭터 코로네의 전용무기 Orayo를 추가하였습니다.

# 동영상

https://github.com/KIA-PROGRAMMING-38/HoloCure/assets/120005225/d9c4fbc2-ce94-4d49-be14-45cc22dd116d

# 관련 이슈

- #207 
- #205 