### PR TITLE
[Feature] #252 전용 무기 DualKatana 추가

### DIFF
--- a/HoloCure/Assets/Resources/3_Prefab/Dual Katana.prefab
+++ b/HoloCure/Assets/Resources/3_Prefab/Dual Katana.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 2590271084113620909}
   - component: {fileID: 1317066095645809325}
   - component: {fileID: 8647257144565252516}
-  - component: {fileID: 7272296172817130580}
+  - component: {fileID: -6122557288461652625}
   m_Layer: 0
   m_Name: Dual Katana
   m_TagString: Untagged
@@ -142,7 +142,7 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
---- !u!114 &7272296172817130580
+--- !u!114 &-6122557288461652625
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -151,6 +151,6 @@ MonoBehaviour:
   m_GameObject: {fileID: 2264239724104728841}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6a262e27c2b90ef45b1d6a5d7afd6d09, type: 3}
+  m_Script: {fileID: 11500000, guid: 391225e82f356ad489c0abfa73400c6e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/HoloCure/Assets/Scripts/Weapon/DualKatana.cs
+++ b/HoloCure/Assets/Scripts/Weapon/DualKatana.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+using Util;
+
+public class DualKatana : CursorTargetingMeleeWeapon
+{
+    private const float ANGLE_BETWEEN_STRIKES = 30f;
+    private float[] _angles = new float[Define.MAX_STRIKE_COUNT];
+    private Quaternion _centerStrikeRotation;
+
+    public override void LevelUp()
+    {
+        base.LevelUp();
+        Utils.SetAnglesFromCenter(_angles, weaponData.StrikeCount, ANGLE_BETWEEN_STRIKES);
+    }
+
+    protected override void SetupStrikeOnPerform(WeaponStrike strike, int strikeIndex)
+    {
+        if (strikeIndex == 0)
+        {
+            _centerStrikeRotation = strike.transform.rotation;
+        }
+        strike.transform.rotation = _centerStrikeRotation * Quaternion.AngleAxis(_angles[strikeIndex], Vector3.back);
+
+        Managers.Sound.Play(SoundID.DualKatana);
+    }
+}

--- a/HoloCure/Assets/Scripts/Weapon/DualKatana.cs.meta
+++ b/HoloCure/Assets/Scripts/Weapon/DualKatana.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 391225e82f356ad489c0abfa73400c6e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# 변경된 기능
신규캐릭터 아야메의 전용무기 DualKatana를 추가하였습니다.

# 동영상

https://github.com/KIA-PROGRAMMING-38/HoloCure/assets/120005225/be93c624-872c-419b-9d20-0253df43ee98

# 관련 이슈

- #252 
- #250  